### PR TITLE
Translate to: de en es fr pt sv

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,0 +1,8 @@
+{
+  "manifest_name": {
+    "message": "Skipflix: Netflix-Eröffnungstitel auto-überspringen"
+  },
+  "manifest_description": {
+    "message": "Überspringen Sie den Eröffnungstitel automatisch auf Netflix."
+  }
+}

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "manifest_name": {
+    "message": "Skipflix: Auto Skip Netflix Intro",
+    "description": "The title of the application, displayed in the web store."
+  },
+  "manifest_description": {
+    "message": "Skip opening titles automatically on Netflix.",
+    "description":"The description of the application, displayed in the web store."
+  }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,8 @@
+{
+  "manifest_name": {
+    "message": "Skipflix: auto-salta la intro en Netflix"
+  },
+  "manifest_description": {
+    "message": "Salta los títulos de apertura automáticamente en Netflix."
+  }
+}

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,8 @@
+{
+  "manifest_name": {
+    "message": "Skipflix: auto sauter l'intro de Netflix"
+  },
+  "manifest_description": {
+    "message": "Passer les titres d'ouverture automatiquement sur Netflix."
+  }
+}

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -1,0 +1,8 @@
+{
+  "manifest_name": {
+    "message": "Skipflix: auto-pular abertura no Netflix"
+  },
+  "manifest_description": {
+    "message": "Pule os créditos iniciais automaticamente no Netflix."
+  }
+}

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -1,0 +1,8 @@
+{
+  "manifest_name": {
+    "message": "Skipflix: auto-hoppa Netflix intro"
+  },
+  "manifest_description": {
+    "message": "Hoppa över öppnings titlar automatiskt på Netflix."
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "short_name": "Skipflix",
   "description": "__MSG_manifest_description__",
   "default_locale": "en",
-  "version": "1.1",
+  "version": "1.2",
 
   "browser_action": {
     "default_icon": "icon48.png"

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,10 @@
 {
   "manifest_version": 2,
 
-  "name": "Skipflix: Auto Skip Netflix Intro",
+  "name": "__MSG_manifest_name__",
   "short_name": "Skipflix",
-  "description": "Skip opening credits automatically on Netflix.",
+  "description": "__MSG_manifest_description__",
+  "default_locale": "en",
   "version": "1.1",
 
   "browser_action": {


### PR DESCRIPTION
I want to provide translations for the extension title and description. From the Chrome Web Store statistics, these are the languages with more than 200 downloads, so I picked them for this round of translation:

- English
- Portuguese
- German
- Spanish
- French
- Swedish

I used Google Translate and some good guessing to shorten the title, since I don't know people who speak all these languages.